### PR TITLE
Hazelcast Spring Annotations

### DIFF
--- a/features/src/main/resources/features.xml
+++ b/features/src/main/resources/features.xml
@@ -2,32 +2,41 @@
     xmlns="http://karaf.apache.org/xmlns/features/v1.0.0"
     name="com.github.avdyk.osgi.caching.test">
 
-    <feature name="com.github.avdyk.osgi.caching.test-api" version="${api.version}">
+    <feature name="com.github.avdyk.osgi.caching.test-prerequisites" version="${project.version}">
+        <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
+    </feature>
+
+    <feature name="com.github.avdyk.osgi.caching.test-api" version="${project.version}">
         <bundle>mvn:${project.groupId}/com.github.avdyk.osgi.caching.test-api/${api.version}</bundle>
     </feature>
 
-    <feature name="com.github.avdyk.osgi.caching.test-core" version="${core.version}">
-        <feature version="${api.version}">com.github.avdyk.osgi.caching.test-api</feature>
+    <feature name="com.github.avdyk.osgi.caching.test-core" version="${project.version}">
+        <feature version="${project.version}">com.github.avdyk.osgi.caching.test-api</feature>
         <bundle>mvn:${project.groupId}/core/${core.version}</bundle>
     </feature>
 
-    <feature name="com.github.avdyk.osgi.caching.test-hazelcast-spring-annotations" version="${hazelcast-spring-annotations.version}">
-        <feature version="${api.version}">com.github.avdyk.osgi.caching.test-api</feature>
+    <feature name="com.github.avdyk.osgi.caching.test-core-hazelcast-spring-annotations" version="${project.version}">
+        <feature version="${project.version}">com.github.avdyk.osgi.caching.test-api</feature>
         <bundle>mvn:${project.groupId}/hazelcast-spring-annotations/${hazelcast-spring-annotations.version}</bundle>
+        <configfile
+            finalname="/deploy/hazelcast-cache-manager.xml"
+            override="false">
+            mvn:${project.groupId}/hazelcast-spring-annotations/${hazelcast-spring-annotations.version}/deploy/cache-manager
+        </configfile>
     </feature>
 
-    <feature name="com.github.avdyk.osgi.caching.test-core-hazelcast-spring" version="${hazelcast-spring.version}">
-        <feature version="${api.version}">com.github.avdyk.osgi.caching.test-api</feature>
+    <feature name="com.github.avdyk.osgi.caching.test-core-hazelcast-spring" version="${project.version}">
+        <feature version="${project.version}">com.github.avdyk.osgi.caching.test-api</feature>
         <bundle>mvn:${project.groupId}/hazelcast-spring/${hazelcast-spring.version}</bundle>
     </feature>
 
-    <feature name="com.github.avdyk.osgi.caching.test-core-jcache-annotations" version="${jcache-annotations.version}">
-        <feature version="${api.version}">com.github.avdyk.osgi.caching.test-api</feature>
+    <feature name="com.github.avdyk.osgi.caching.test-core-jcache-annotations" version="${project.version}">
+        <feature version="${project.version}">com.github.avdyk.osgi.caching.test-api</feature>
         <bundle>mvn:${project.groupId}/jcache-annotations/${jcache-annotations.version}</bundle>
     </feature>
 
-    <feature name="com.github.avdyk.osgi.caching.test-command" version="${command.version}">
-        <feature version="${api.version}">com.github.avdyk.osgi.caching.test-api</feature>
+    <feature name="com.github.avdyk.osgi.caching.test-command" version="${project.version}">
+        <feature version="${project.version}">com.github.avdyk.osgi.caching.test-api</feature>
         <bundle>mvn:${project.groupId}/com.github.avdyk.osgi.caching.test-command/${command.version}</bundle>
     </feature>
 

--- a/hazelcast-spring-annotations/pom.xml
+++ b/hazelcast-spring-annotations/pom.xml
@@ -105,6 +105,28 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/deploy/cache-manager.xml</file>
+                                    <type>deploy</type>
+                                    <classifier>cache-manager</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-spring-annotations/src/main/resources/META-INF/spring/module.xml
+++ b/hazelcast-spring-annotations/src/main/resources/META-INF/spring/module.xml
@@ -17,11 +17,4 @@
     <cache:annotation-driven
         cache-manager="cacheManager"/>
 
-    <bean
-        id="cacheManager"
-        class="com.hazelcast.spring.cache.HazelcastCacheManager">
-
-        <constructor-arg ref="hazelcastInstance"/>
-    </bean>
-
 </beans>

--- a/hazelcast-spring-annotations/src/main/resources/deploy/cache-manager.xml
+++ b/hazelcast-spring-annotations/src/main/resources/deploy/cache-manager.xml
@@ -9,12 +9,19 @@
         http://www.springframework.org/schema/osgi/spring-osgi.xsd">
 
     <osgi:reference
+        id="hazelcastInstance"
+        interface="com.hazelcast.core.HazelcastInstance"/>
+
+    <bean
         id="cacheManager"
-        interface="org.springframework.cache.CacheManager"/>
+        class="com.hazelcast.spring.cache.HazelcastCacheManager">
+
+        <constructor-arg ref="hazelcastInstance"/>
+    </bean>
 
     <osgi:service
-        id="osgiDeveloperServiceExposed"
-        ref="osgiDeveloperService"
-        interface="com.github.avdyk.osgi.caching.test.api.DeveloperService"/>
+        id="cacheManageService"
+        ref="cacheManager"
+        interface="org.springframework.cache.CacheManager"/>
 
 </beans>


### PR DESCRIPTION
Makes the cache works with Spring annotations. It uses an OSGi reference of Spring...CacheManager, so completely hazelcast unaware!!!
